### PR TITLE
Add table structural information

### DIFF
--- a/js/modules/calendar_generator.js
+++ b/js/modules/calendar_generator.js
@@ -263,7 +263,7 @@ Part of AccDC, a Cross-Browser JavaScript accessibility API, distributed under t
 									dc.iter = dc.iterE = (di + 6) > 6 ? -1 + di : di + 6;
 									dc.iterS = di;
 								}
-								dc.source += '<th class="week" title="' + d.lng + '" role="presentation"><span>' + d.shrt + '</span></th>';
+								dc.source += '<th scope="col" class="week" title="' + d.lng + '" role="presentation"><span>' + d.shrt + '</span></th>';
 							}
 							dc.source += '</tr><tr role="presentation">';
 							var m = new Date();


### PR DESCRIPTION
In order to satisfy WCAG 1.3.1 (Level A):
Table structural information must be provided.
<th> elements must have the scope attribute